### PR TITLE
Bugfix: Vertical layout: Japanese text isn't rotated in fo:block-container and fo:table

### DIFF
--- a/fop-core/src/main/java/org/apache/fop/layoutmgr/BlockContainerLayoutManager.java
+++ b/fop-core/src/main/java/org/apache/fop/layoutmgr/BlockContainerLayoutManager.java
@@ -197,7 +197,7 @@ public class BlockContainerLayoutManager extends SpacedBorderedPaddedBlockLayout
         childLC.setStackLimitBP(
                 context.getStackLimitBP().minus(MinOptMax.getInstance(relDims.bpd)));
         childLC.setRefIPD(relDims.ipd);
-        childLC.setWritingMode(getBlockContainerFO().getWritingMode());
+        childLC.setWritingMode(context.getWritingMode());
         return childLC;
     }
 

--- a/fop-core/src/main/java/org/apache/fop/layoutmgr/table/RowGroupLayoutManager.java
+++ b/fop-core/src/main/java/org/apache/fop/layoutmgr/table/RowGroupLayoutManager.java
@@ -116,6 +116,7 @@ class RowGroupLayoutManager {
                     LayoutContext childLC = LayoutContext.newInstance();
                     childLC.setStackLimitBP(context.getStackLimitBP()); //necessary?
                     childLC.setRefIPD(spanWidth);
+                    childLC.setWritingMode(context.getWritingMode());
 
                     //Get the element list for the cell contents
                     List<ListElement> elems = primary.getCellLM().getNextKnuthElements(

--- a/fop-core/src/main/java/org/apache/fop/layoutmgr/table/TableCellLayoutManager.java
+++ b/fop-core/src/main/java/org/apache/fop/layoutmgr/table/TableCellLayoutManager.java
@@ -184,6 +184,8 @@ public class TableCellLayoutManager extends BlockStackingLayoutManager {
         LayoutManager prevLM = null; // previously active LM
         while ((curLM = getChildLM()) != null) {
             LayoutContext childLC = LayoutContext.newInstance();
+            childLC.setWritingMode(context.getWritingMode());
+
             // curLM is a ?
             childLC.setStackLimitBP(context.getStackLimitBP().minus(stackLimit));
             childLC.setRefIPD(cellIPD);

--- a/fop-core/src/main/java/org/apache/fop/layoutmgr/table/TableLayoutManager.java
+++ b/fop-core/src/main/java/org/apache/fop/layoutmgr/table/TableLayoutManager.java
@@ -273,6 +273,7 @@ public class TableLayoutManager extends SpacedBorderedPaddedBlockLayoutManager
                                  stackSize));*/
         childLC.setRefIPD(context.getRefIPD());
         childLC.copyPendingMarksFrom(context);
+        childLC.setWritingMode(context.getWritingMode());
 
         contentKnuthElements = contentLM.getNextKnuthElements(childLC, alignment);
         //Set index values on elements coming from the content LM


### PR DESCRIPTION
fixed issue https://github.com/metanorma/xmlgraphics-fop/issues/8